### PR TITLE
feat: Open cerebro window on Active screen

### DIFF
--- a/app/lib/getWindowPosition.js
+++ b/app/lib/getWindowPosition.js
@@ -28,7 +28,10 @@ export default ({ width, heightWithResults }) => {
     ? heightWithResults
     : MIN_VISIBLE_RESULTS * RESULT_HEIGHT + INPUT_HEIGHT
 
-  const display = screen.getPrimaryDisplay()
+  const display = screen.getDisplayNearestPoint(
+    screen.getCursorScreenPoint()
+  )
+
   const positions = config.get('positions') || {}
 
   if (display.id in positions) {

--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -51,6 +51,7 @@ export default ({ src, isDev }) => {
   const showMainWindow = () => {
     mainWindow.show()
     mainWindow.focus()
+
   }
 
   // Setup event listeners for main window
@@ -69,7 +70,10 @@ export default ({ src, isDev }) => {
     if (!mainWindow.isVisible()) {
       return
     }
-    const display = screen.getPrimaryDisplay()
+    const display = screen.getDisplayNearestPoint(
+      screen.getCursorScreenPoint()
+    )
+
     const positions = config.get('positions') || {}
     positions[display.id] = mainWindow.getPosition()
     config.set('positions', positions)

--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -51,7 +51,6 @@ export default ({ src, isDev }) => {
   const showMainWindow = () => {
     mainWindow.show()
     mainWindow.focus()
-
   }
 
   // Setup event listeners for main window


### PR DESCRIPTION
This PR aims to fix #131.
Instead of using the "Default" display to open Cerebro, it will use the "current" display, based on the cursor position on the screen.

The main functionality is working, but you still see for brief moments, the Cerebro window opened in the previous screen, before appearing on the new screen. A little bit annoying but not a big deal for me.

I also noticed, sometimes I need to press the Hotkey 2 times before Cerebro opens. Not sure if its related with any of the changes I made.

This PR was only tested on Linux but it uses standard Electron functions, so it should work fine elsewhere.