### PR TITLE
Fix/windows notifications

### DIFF
--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -36,6 +36,10 @@ export default ({ src, isDev }) => {
 
   const mainWindow = new BrowserWindow(browserWindowOptions)
 
+  // Setting required for Windows (10 creators update) notifications
+  // MUST be equal to appId in package.json!
+  app.setAppUserModelId('com.cerebroapp.Cerebro')
+
   // Float main window above full-screen apps
   mainWindow.setAlwaysOnTop(true, 'modal-panel')
 


### PR DESCRIPTION
Fix for Windows (10, creators update, possibly others). Allows notifications through `new Notification` to work, if these are enabled under `Settings: notifications and actions`.