### PR TITLE
Feature/allow transparency

### DIFF
--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -26,6 +26,7 @@ export default ({ src, isDev }) => {
     y,
     frame: false,
     resizable: false,
+    transparent: true,
     // Show main window on launch only when application started for the first time
     show: config.get('firstStart')
   }


### PR DESCRIPTION
Something odd going on with cached results when I closed the previous PR - this single line **is** required for allowing plugins to hide the window without losing state (such as for screenshots).

That is, unless the entire system to hide the main window is overhauled.

The moving of CSS from html+body to body wasn't really necessary so I left it as is.