### PR TITLE
fix: Move event handling to before the 'preventedDefault' property is read

### DIFF
--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -290,10 +290,10 @@ class Cerebro extends Component {
     this.props.actions.reset()
     trackSelectItem(item.plugin)
     const event = wrapEvent(realEvent)
+    item.onSelect(event)
     if (!event.defaultPrevented) {
       this.electronWindow.hide()
     }
-    item.onSelect(event)
   }
 
   /**


### PR DESCRIPTION
Fixes plugins not being able to call `event.preventDefault()` with the desired effect