### PR TITLE
Add config option to hide on blur

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -30,6 +30,7 @@ const defaultSettings = memoize(() => {
     firstStart: true,
     developerMode: false,
     cleanOnHide: true,
+    hideOnBlur: true,
     skipDonateDialog: false,
     lastShownDonateDialog: null,
     plugins: {},

--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -57,7 +57,7 @@ export default ({ src, isDev }) => {
   globalShortcut.register(shortcut, toggleMainWindow)
 
   mainWindow.on('blur', () => {
-    if (!isDev()) {
+    if (!isDev() && config.get('hideOnBlur')) {
       // Hide window on blur in production
       // In development we usually use developer tools that can blur a window
       mainWindow.hide()


### PR DESCRIPTION
On some tiling window managers, simply moving the mouse outside the cerebro window
blurs it (and closes it), which gets very frustrating. This adds a configuration option to disable
this behavior.

The default value keeps the current behavior.