### PR TITLE
Fix serif font on systems that do not define a system font

### DIFF
--- a/app/main/css/themes/dark.css
+++ b/app/main/css/themes/dark.css
@@ -1,7 +1,7 @@
 :root {
   /* Main fonts and colors */
   --main-background-color: rgba(62, 65, 67, 1);
-  --main-font: system;
+  --main-font: system, sans-serif;
   --main-font-color: white;
 
   /* border styles */

--- a/app/main/css/themes/light.css
+++ b/app/main/css/themes/light.css
@@ -1,7 +1,7 @@
 :root {
   /* Main fonts and colors */
   --main-background-color: rgba(255, 255, 255, 1);
-  --main-font: system;
+  --main-font: system, sans-serif;
   --main-font-color: #000000;
 
   /* border styles */


### PR DESCRIPTION
Some linux distributions that do not use a desktop environment do
not define a system font. On these systems, the system-font css file
does not work if none of the font families are matched (and it
seems chrome ignores it anyway).

I added sans-serif as a fallback font, which is usually always defined
in fontconfig as a sans-serif font.

Without this, cerebro uses an ugly ans obscure serif font due to
no fallback having been found.

