### PR TITLE
feat: add proxy in cerebro settings

### DIFF
--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -115,6 +115,12 @@ export default ({ src, isDev }) => {
     })
   })
 
+  mainWindow.settingsChanges.on('proxy', (value) => {
+    mainWindow.webContents.session.setProxy({
+      proxyRules: value
+    })
+  })
+
   // Handle window.hide: if cleanOnHide value in preferences is true
   // we clear all results and show empty window every time
   const resetResults = () => {

--- a/app/plugins/core/settings/Settings/index.js
+++ b/app/plugins/core/settings/Settings/index.js
@@ -61,7 +61,7 @@ class Settings extends Component {
           label="Proxy"
           value={proxy}
           onChange={value => this.changeConfig('proxy', value)}
-        ></Text>
+        />
         <Checkbox
           label="Open at login"
           value={openAtLogin}

--- a/app/plugins/core/settings/Settings/index.js
+++ b/app/plugins/core/settings/Settings/index.js
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react'
 import Hotkey from './Hotkey'
 import countries from './countries'
-import { Select, Checkbox, Wrapper } from 'cerebro-ui/Form'
+import { Select, Checkbox, Wrapper, Text } from 'cerebro-ui/Form'
 import loadThemes from 'lib/loadThemes'
 import styles from './styles.css'
 
@@ -14,6 +14,7 @@ class Settings extends Component {
       showInTray: get('showInTray'),
       country: get('country'),
       theme: get('theme'),
+      proxy: get('proxy'),
       developerMode: get('developerMode'),
       cleanOnHide: get('cleanOnHide'),
       pluginsSettings: get('plugins'),
@@ -31,7 +32,7 @@ class Settings extends Component {
   }
   render() {
     const {
-      hotkey, showInTray, country, theme, developerMode, cleanOnHide, openAtLogin,
+      hotkey, showInTray, country, theme, proxy, developerMode, cleanOnHide, openAtLogin,
       trackingEnabled, crashreportingEnabled
     } = this.state
 
@@ -56,6 +57,11 @@ class Settings extends Component {
           options={loadThemes()}
           onChange={value => this.changeConfig('theme', value)}
         />
+        <Text
+          label="Proxy"
+          value={proxy}
+          onChange={value => this.changeConfig('proxy', value)}
+        ></Text>
         <Checkbox
           label="Open at login"
           value={openAtLogin}


### PR DESCRIPTION
When i use this application, i found i can not use partial function in some plugins, for example: i cannot use preview in cerebro-google plugin because i come from china and if i want to use the google api like 'http://suggestqueries.google.com/complete/search?client=firefox&q=${query}', i need set a proxy like socks proxy.But there is not a place in cerebro settings to set proxy, and this problem also confuse others, so i did this. 
![图片](https://user-images.githubusercontent.com/32331521/122588918-3bae1880-d092-11eb-9e16-94bb42bdf586.png)

The ProxyRule can refer to this doc 
https://www.electronjs.org/docs/api/session#sessetproxyconfig