### PR TITLE
fix: removeNoise function not working correctly

### DIFF
--- a/app/plugins/core/plugins/format.js
+++ b/app/plugins/core/plugins/format.js
@@ -1,26 +1,35 @@
-import { flow, lowerCase, words, capitalize, trim, map, join } from 'lodash/fp'
+import { flow, words, capitalize, trim, map, join } from 'lodash/fp'
 
 /**
- * Remove unnecessary information from plugin name or description
+ * Remove unnecessary information from plugin description
  * like `Cerebro plugin for`
  * @param  {String} str
  * @return {String}
  */
-const removeNoise = (str) => (
+const removeDescriptionNoise = (str) => (
   (str || '').replace(/^cerebro\s?(plugin)?\s?(to|for)?/i, '')
 )
 
-export const name = flow(
-  lowerCase,
-  removeNoise,
+
+/**
+ * Remove unnecessary information from plugin name
+ * like `cerebro-plugin-` or `cerebro-`
+ * @param  {String} str
+ * @return {String}
+ */
+const removeNameNoise = (str) => (
+  (str || '').replace(/^cerebro-(plugin)?-?/i, '')
+)
+
+export const name = (text = '') => flow(
   trim,
   words,
   map(capitalize),
   join(' ')
-)
+)(removeNameNoise(text.toLowerCase()))
 
 export const description = flow(
-  removeNoise,
+  removeDescriptionNoise,
   trim,
   capitalize,
 )


### PR DESCRIPTION
Hi,
I am currently developing some cerebro plugins and have noticed that the current function that removes words from plugin names is not working correctly. This is the case of `cerebro-todoist`, whose name is modified appearing only "Doist". I've slightly modified the regex for each usage (name and description) so there should no longer be a problem with names like "cerebro-toggle-..." appearing as "ggle".

The new regex removes words like 'cerebro-' and 'cerebro-plugin-' from the plugins name but not affecting to the rest of the name.
![image](https://user-images.githubusercontent.com/77246331/169022947-c1df1fa3-e9e9-4df6-977d-57854df4f359.png)

Before

![image](https://user-images.githubusercontent.com/77246331/169023395-11a07dfc-0225-433f-ad67-a18eb926a75e.png)

After
![image](https://user-images.githubusercontent.com/77246331/169023131-55da2f51-ab55-4c72-a8af-8295bd20db4b.png)

