### PR TITLE
fix: Show local plugins when offline

### DIFF
--- a/app/plugins/core/plugins/Preview/index.js
+++ b/app/plugins/core/plugins/Preview/index.js
@@ -69,47 +69,36 @@ class Preview extends Component {
       version,
       description,
       repo,
-      isInstalled,
+      isInstalled = false,
       isDebugging,
       installedVersion,
-      isUpdateAvailable
+      isUpdateAvailable = false
     } = this.props
     const githubRepo = repo && repo.match(/^.+github.com\/([^\/]+\/[^\/]+).*?/)
     const { runningAction, showSettings } = this.state
     const settings = plugins[name] ? plugins[name].settings : null
     return (
       <div className={styles.preview} key={name}>
-        <h2>
-          {format.name(name)}
-          {' '}
-          (
-          {version}
-          )
-        </h2>
+        <h2>{`${format.name(name)} (${version})`}</h2>
+
         <p>{format.description(description)}</p>
         <KeyboardNav>
           <div className={styles.header}>
-            {
-              settings
-                && (
-                <KeyboardNavItem
-                  onSelect={() => this.setState({ showSettings: !this.state.showSettings })}
-                >
-                  Settings
-                </KeyboardNavItem>
-                )
-            }
+            { settings && (
+              <KeyboardNavItem
+                onSelect={() => this.setState({ showSettings: !this.state.showSettings })}
+              >
+                Settings
+              </KeyboardNavItem>
+            )}
             {showSettings && <Settings name={name} settings={settings} />}
-            {
-              !isInstalled && !isDebugging
-                && (
-                <ActionButton
-                  action={this.pluginAction(name, 'install')}
-                  text={runningAction === 'install' ? 'Installing...' : 'Install'}
-                  onComplete={this.onComplete}
-                />
-                )
-            }
+            { !isInstalled && !isDebugging && (
+            <ActionButton
+              action={this.pluginAction(name, 'install')}
+              text={runningAction === 'install' ? 'Installing...' : 'Install'}
+              onComplete={this.onComplete}
+            />
+            )}
             {
               isInstalled
                 && (
@@ -159,9 +148,9 @@ Preview.propTypes = {
   description: PropTypes.string,
   repo: PropTypes.string,
   installedVersion: PropTypes.string,
-  isInstalled: PropTypes.bool.isRequired,
+  isInstalled: PropTypes.bool,
   isDebugging: PropTypes.bool,
-  isUpdateAvailable: PropTypes.bool.isRequired,
+  isUpdateAvailable: PropTypes.bool,
   onComplete: PropTypes.func.isRequired,
 }
 

--- a/app/plugins/core/plugins/format.js
+++ b/app/plugins/core/plugins/format.js
@@ -1,4 +1,6 @@
-import { flow, words, capitalize, trim, map, join } from 'lodash/fp'
+import {
+  flow, words, capitalize, trim, map, join
+} from 'lodash/fp'
 
 /**
  * Remove unnecessary information from plugin description
@@ -6,10 +8,9 @@ import { flow, words, capitalize, trim, map, join } from 'lodash/fp'
  * @param  {String} str
  * @return {String}
  */
-const removeDescriptionNoise = str => (
+const removeDescriptionNoise = (str) => (
   (str || '').replace(/^cerebro\s?(plugin)?\s?(to|for)?/i, '')
 )
-
 
 /**
  * Remove unnecessary information from plugin name
@@ -17,7 +18,7 @@ const removeDescriptionNoise = str => (
  * @param  {String} str
  * @return {String}
  */
-const removeNameNoise = str => (
+const removeNameNoise = (str) => (
   (str || '').replace(/^cerebro-(plugin)?-?/i, '')
 )
 
@@ -34,8 +35,8 @@ export const description = flow(
   capitalize,
 )
 
-export const version = plugin => (
-  plugin.isUpdateAvailable ?
-    `${plugin.installedVersion} → ${plugin.version}` :
-    plugin.version
+export const version = (plugin) => (
+  plugin.isUpdateAvailable
+    ? `${plugin.installedVersion} → ${plugin.version}`
+    : plugin.version
 )

--- a/app/plugins/core/plugins/getAvailablePlugins.js
+++ b/app/plugins/core/plugins/getAvailablePlugins.js
@@ -1,25 +1,30 @@
-import { flow, map, sortBy } from 'lodash/fp'
-
 /**
  * API endpoint to search all cerebro plugins
  * @type {String}
  */
 const URL = 'https://registry.npmjs.com/-/v1/search?from=0&size=500&text=keywords:cerebro-plugin,cerebro-extracted-plugin'
 
+const sortByPopularity = (a, b) => a.score.detail.popularity > b.score.detail.popularity ? -1 : 1
+
 /**
  * Get all available plugins for Cerebro
- * @return {Promise<Object>}
+ * @return {Promise<Array>}
  */
 export default async () => {
-  const json = await fetch(URL).then(res => res.json())
-  return flow(
-    sortBy(p => -p.score.detail.popularity),
-    map(p => ({
+  if (!navigator.onLine) return []
+  try {
+    const { objects: plugins } = await fetch(URL).then((res) => res.json())
+    plugins.sort(sortByPopularity)
+
+    return plugins.map((p) => ({
       name: p.package.name,
       version: p.package.version,
       description: p.package.description,
       homepage: p.package.links.homepage,
       repo: p.package.links.repository
     }))
-  )(json.objects)
+  } catch (err) {
+    console.log(err)
+    return []
+  }
 }

--- a/app/plugins/core/plugins/getDebuggingPlugins.js
+++ b/app/plugins/core/plugins/getDebuggingPlugins.js
@@ -8,7 +8,7 @@ const isSymlink = (file) => lstatSync(path.join(modulesDirectory, file)).isSymbo
  * Get list of all plugins that are currently in debugging mode.
  * These plugins are symlinked by [create-cerebro-plugin](https://github.com/cerebroapp/create-cerebro-plugin)
  *
- * @return {Promise<String[]>}
+ * @return {Promise<string[]>}
  */
 export default async () => {
   const files = readdirSync(modulesDirectory)

--- a/app/plugins/core/plugins/getInstalledPlugins.js
+++ b/app/plugins/core/plugins/getInstalledPlugins.js
@@ -6,9 +6,9 @@ const readPackageJson = () => readFileSync(packageJsonPath, { encoding: 'utf8' }
 /**
  * Get list of all installed plugins with versions
  *
- * @return {Promise<Object>}
+ * @return {Promise<[name: string, version: string][]>}
  */
 export default async () => {
   const packageJson = JSON.parse(readPackageJson())
-  return packageJson.dependencies
+  return Object.entries(packageJson.dependencies)
 }


### PR DESCRIPTION
I fixed a bug that was causing cerebro to fail when no connection was available.
Now `plugins` command will continue working when using cerebro offline
For now no description is available when offline.


## Then
![image](https://user-images.githubusercontent.com/77246331/182138710-f81b0665-46d0-401d-b4c8-8f847f1a0e9f.png)

## Now
![image](https://user-images.githubusercontent.com/77246331/182139510-a773ca90-bd1b-42f6-b55d-f4167a96f5fa.png)
