### PR TITLE
fix: disable autostart when running `yarn dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,22 @@ And then install dependencies:
 yarn
 ```
 
-### Run
+### Run in development mode
 
 ```bash
 $ yarn run dev
 ```
 
 > Note: requires a node version >=16.x
+### Build executable from source
 
+If you would like to install one version but the package is not published you can use this command to build executable file from source:
+
+```bash
+$ yarn package
+```
+
+> Note: in CI we use `yarn build` as there is an action to package and publish the executables
 ### Resolve common issues
 1. `AssertionError: Current node version is not supported for development` on npm postinstall.
 After `yarn` postinstall script checks node version. If you see this error you have to check node and npm version in `package.json` `devEngines` section and install proper ones.
@@ -88,14 +96,6 @@ Use shortcut `ctrl+space` to open app window and type `Cerebro Settings`. There 
 *Linux*: `$XDG_CONFIG_HOME/Cerebro/config.json`  or `~/.config/Cerebro/config.json`
 
 *macOS*: `~/Library/Application Support/Cerebro/config.json`
-
-
-### Package
-Use this command to build `.app` file:
-
-```bash
-$ yarn build
-```
 
 ## For developers
 

--- a/app/main/createWindow/autoStart.js
+++ b/app/main/createWindow/autoStart.js
@@ -1,11 +1,12 @@
 import { app } from 'electron'
 import AutoLaunch from 'auto-launch'
 
-let appLauncher
+const isLinux = !['win32', 'darwin'].includes(process.platform)
+const isDevelopment = process.env.NODE_ENV === 'development'
 
-const isLinux = ['win32', 'darwin'].indexOf(process.platform) === -1
-
-if (isLinux) { appLauncher = new AutoLaunch({ name: 'Cerebro' }) }
+const appLauncher = isLinux
+  ? new AutoLaunch({ name: 'Cerebro' })
+  : null
 
 const isEnabled = async () => (
   isLinux
@@ -13,14 +14,15 @@ const isEnabled = async () => (
     : app.getLoginItemSettings().openAtLogin
 )
 
-const set = (openAtLogin) => {
+const set = async (openAtLogin) => {
+  const openAtStartUp = openAtLogin && !isDevelopment
   if (isLinux) {
-    return openAtLogin
+    return openAtStartUp
       ? appLauncher.enable()
       : appLauncher.disable()
   }
 
-  return app.setLoginItemSettings({ openAtLogin })
+  return app.setLoginItemSettings({ openAtLogin: openAtStartUp })
 }
 
 export default { isEnabled, set }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start-hot": "yarn build-main-dev && cross-env HOT=1 NODE_ENV=development ./node_modules/.bin/electron -r @babel/register ./app",
     "release": "build -mwl --draft",
     "dev": "run-p hot-server start-hot",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "package": "yarn build && npx electron-builder"
   },
   "build": {
     "productName": "Cerebro",


### PR DESCRIPTION
This PR disables the autostart option when running the app in development mode (not includes the development option in the production app, just `yarn dev`).
Autostart was causing an electron popup window on start because it fails while trying to start an executable that doesn't exist, as the app isn't compiled. More info [here](https://stackoverflow.com/a/60780958)

To delete de entry in the start options of the PC users can run Cerebro with `yarn dev` and edit the settings disabling (and now also enablig) the option. This will clear the entry and the window won't show again. Autostart is now never activated on development mode.

fix #573 