### PR TITLE
fix: clipboard issues

### DIFF
--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -197,10 +197,13 @@ class Cerebro extends Component {
     if (event.metaKey || event.ctrlKey) {
       if (event.keyCode === 67) {
         // Copy to clipboard on cmd+c
-        const text = this.highlightedResult().clipboard
+        const text = this.highlightedResult()?.clipboard || this.props.term
         if (text) {
           clipboard.writeText(text)
           this.props.actions.reset()
+          if (!event.defaultPrevented) {
+            this.electronWindow.hide()
+          }
           event.preventDefault()
         }
         return


### PR DESCRIPTION
- [x] Close cerebro when copy to clipboard (if not default prevented)
- [x] Fixed an issue when highlightedResult is undefined or the plugin has not a clipboard field. Now, if the selected entry doesn't have a clipboard field, the input term is copied by default.

fix #447

