### PR TITLE
feature: developer tools shortcut

### DIFF
--- a/app/main/createWindow/AppTray.js
+++ b/app/main/createWindow/AppTray.js
@@ -74,12 +74,12 @@ export default class AppTray {
         submenu: [
           {
             label: 'DevTools (main)',
-            accelerator: 'CmdOrCtrl+Alt+I',
+            accelerator: 'CmdOrCtrl+Shift+I',
             click: () => mainWindow.webContents.openDevTools({ mode: 'detach' })
           },
           {
             label: 'DevTools (background)',
-            accelerator: 'CmdOrCtrl+Alt+B',
+            accelerator: 'CmdOrCtrl+Shift+B',
             click: () => backgroundWindow.webContents.openDevTools({ mode: 'detach' })
           },
           {

--- a/app/main/createWindow/AppTray.js
+++ b/app/main/createWindow/AppTray.js
@@ -58,7 +58,7 @@ export default class AppTray {
       separator,
       {
         label: 'Check for updates',
-        click: () => checkForUpdates(),
+        click: checkForUpdates,
       },
       separator,
       {
@@ -74,10 +74,12 @@ export default class AppTray {
         submenu: [
           {
             label: 'DevTools (main)',
+            accelerator: 'CmdOrCtrl+Alt+I',
             click: () => mainWindow.webContents.openDevTools({ mode: 'detach' })
           },
           {
             label: 'DevTools (background)',
+            accelerator: 'CmdOrCtrl+Alt+B',
             click: () => backgroundWindow.webContents.openDevTools({ mode: 'detach' })
           },
           {
@@ -96,7 +98,11 @@ export default class AppTray {
       label: 'Quit Cerebro',
       click: () => app.quit()
     })
-    return Menu.buildFromTemplate(template)
+
+    const menu = Menu.buildFromTemplate(template)
+    Menu.setApplicationMenu(menu)
+
+    return menu
   }
 
   /**

--- a/docs/plugins/plugin-structure.md
+++ b/docs/plugins/plugin-structure.md
@@ -6,6 +6,8 @@ This is a minimum source code of your plugin:
 export const fn = (scope) => console.log(scope.term)
 ```
 
+> You can open the developer tools by pressing `ctrl+shift+i`(for the main window) and `ctrl+shift+b`(for the background). Developer mode should be enabled from the settings
+
 This plugin will write to console all changes in your search field of Cerebro app. So, `fn` key is a heart of your plugin: this function receives `scope` object and you can send results back to Cerebro. Scope object is:
 
 * `term` – `String`, entered by Cerebro user;
@@ -19,7 +21,6 @@ This plugin will write to console all changes in your search field of Cerebro ap
   * `replaceTerm` – `Function(text: String)`, replace text in main Cerebro input;
   * `hideWindow` – `Function()`, hide main Cerebro window.
 * `settings` - `Object`, contains user provided values of all specified settings keys;
-
 
 Let's show something in results list:
 
@@ -35,17 +36,21 @@ export const fn = (scope) => {
 `scope.display` accepts one result object or array of result objects. Result object is:
 
 ## Basic fields
+
 ### `title`
+
 Type: `String`
 
 Title of your result;
 
 ### `subtitle`
+
 Type: `String`
 
 Subtitle of your result;
 
 ### `icon`
+
 Type: `String`
 
 Icon, that is shown near your result. It can be absolute URL to external image, absolute path to local image or base64-encoded [data-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
@@ -55,20 +60,24 @@ For local icons you can use path to some `.app` file, i.e. `/Applications/Calcul
 ## Advanced fields
 
 ### `id`
+
 Type: `String`
 Use this field when you need to update your result dynamically. Check `id` [example](./examples.md#using-id)
 
 ### `term`
+
 Type: `String`
 
 Autocomplete for your result. So, user can update search term using <kbd>tab</kbd> button;
 
 ### `clipboard`
+
 Type: `String`
 
 Text, that will be copied to clipboard using <kbd>cmd+c</kbd>, when your result is focused;
 
 ### `getPreview`
+
 Type: `Function`
 
 Arguments: no
@@ -76,6 +85,7 @@ Arguments: no
 Function that returns preview for your result. Preview can be an html string or React component;
 
 ### `onSelect`
+
 Type: `Function`.
 Arguments: `event: Event`
 
@@ -88,6 +98,7 @@ onSelect: (event) => actions.open(`http://www.cerebroapp.com`),
 If you don't want to close main window after your action, you should call `event.preventDefault()` in your action.
 
 ### `onKeyDown`
+
 Type: `Function`
 
 Arguments: `event: Event`
@@ -106,19 +117,23 @@ onKeyDown: (event) => {
 You can also prevent default action by `event.preventDefault()`.
 
 ## Advanced plugin fields
+
 Along with `fn`, your module could have more keys:
 
 ### `keyword`
+
 Type: `String`
 
 This field is used for autocomplete. You can prefix your plugin usage by this keyword. Checkout emoji [example](./examples.md#using-keyword-and-name)
 
 ### `name`
+
 Type: `String`
 
 This field is also used for autocomplete and shown as title in results list. Checkout emoji [example](./examples.md#using-keyword-and-name)
 
 ### `initialize`
+
 Type: `Function`
 Arguments: no
 
@@ -127,6 +142,7 @@ Use this function, when you need to prepare some data for your plugin on start. 
 Check `initialize` [example](./examples.md#using-initialize)
 
 ### `initializeAsync`
+
 Type: `Function`
 
 Arguments: `callback: Function(message: Object)` – callback to send data back to main process.
@@ -138,28 +154,31 @@ This function will be executed in another process and you can receive results us
 Check `initializeAsync` and `onMessage` [example](./examples.md#using-initializeasync-and-onmessage)
 
 ### `onMessage`
+
 Type: `Function`
 Arguments: `message: Object` – object that you sent from `initializeAsync`
 
-Use this function to receive data back from your `initializeAsync` function. 
+Use this function to receive data back from your `initializeAsync` function.
 
 Check `initializeAsync` and `onMessage` [example](./examples.md#using-initializeasync-and-onmessage)
 
 ### `settings`
+
 Type: `Object`
 
 This object is used to specify settings that a plugin user can change. Each setting should include a `description` and a `type`. Other keys include:
-  * `label` - `String`, object key for the setting. also used to access it;
-  * `description` -  `String`, description of the setting;
-  * `type` - `String`, used to decide element for rendering a setting:
-    * `string`
-    * `number`
-    * `bool`
-    * `option`
-  * `defaultValue` - `Any`, default value for the setting;
-  * `options` - `Array`, all possible options that can be selected by the user. applicable only for `option`;
-  * `multi` - `Bool`, allows user to select more than one option for `option` settings. applicable only for `option`;
-  * `createable` - `Bool`, allows user created options. applicable only for `option`;
+
+* `label` - `String`, object key for the setting. also used to access it;
+* `description` -  `String`, description of the setting;
+* `type` - `String`, used to decide element for rendering a setting:
+  * `string`
+  * `number`
+  * `bool`
+  * `option`
+* `defaultValue` - `Any`, default value for the setting;
+* `options` - `Array`, all possible options that can be selected by the user. applicable only for `option`;
+* `multi` - `Bool`, allows user to select more than one option for `option` settings. applicable only for `option`;
+* `createable` - `Bool`, allows user created options. applicable only for `option`;
 
 Check `settings` [example](./examples.md#using-settings)
 


### PR DESCRIPTION
Added:
- `ctrl+shift+i` for developer tools in main window
- `ctrl+shift+b` for developer tools in background window

(`ctrl+shift+i` is the shortcut for opening dev tools in chrome so this should be easy to remind)

fix #358 