### PR TITLE
feat: migrate move file to native nodejs

### DIFF
--- a/app/lib/plugins/npm.js
+++ b/app/lib/plugins/npm.js
@@ -5,7 +5,6 @@ import path from 'path'
 import tar from 'tar-fs'
 import zlib from 'zlib'
 import https from 'https'
-import moveFile from 'move-file'
 
 const removeDir = (dir) => rimraf.sync(dir)
 
@@ -51,7 +50,10 @@ const installPackage = async (tarPath, destination, middleware) => {
   })
 
   console.log(`Move ${tempPath} to ${destination}`)
-  moveFile.sync(tempPath, destination)
+  fs.rename(tempPath, destination, (err) => {
+    if (err) throw err
+    console.log('Successfully!')
+  })
 }
 
 /**

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,6 @@
     "David Jiménez <dubisdev@gmail.com> (https://dubis.dev)"
   ],
   "dependencies": {
-    "move-file": "2.1.0",
     "chokidar": "3.5.3",
     "electron-updater": "5.2.1",
     "fix-path": "3.0.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -291,13 +291,6 @@ minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-move-file@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/move-file/-/move-file-2.1.0.tgz#3bec9d34fbe4832df6865f112cda4492b56e8507"
-  integrity sha512-i9qLW6gqboJ5Ht8bauZi7KlTnQ3QFpBCvMvFfEcHADKgHGeJ9BZMO7SFCTwHPV9Qa0du9DYY1Yx3oqlGt30nXA==
-  dependencies:
-    path-exists "^4.0.0"
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -331,11 +324,6 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
I'm removing the move-file dependency and changing it to native. I believe this package is no longer needed.