### PR TITLE
fix: add encoding to background renderer

### DIFF
--- a/app/background/index.html
+++ b/app/background/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <script>
       (function() {
         const script = document.createElement('script');


### PR DESCRIPTION
Finally found that the problem was a bug wth the encoding.
By just adding meta charset to the background, the app is now working.

fix #599 