### PR TITLE
chore: add cerebro-search as default plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ After installation use the default shortcut `ctrl+space` to show the app window.
 
 ### Core plugins
 
-- Search in the web with google suggestions;
-- Search & launch application, i.e. `spotify`;
-- Navigate in file system with file previews (i.e. `~/Dropbox/passport.pdf`);
-- Calculator;
+- Search in the web with your favourite search engine
+- Search & launch application, i.e. `spotify`
+- Navigate in file system with file previews (i.e. `~/Dropbox/passport.pdf`)
+- Calculator
 - Smart converter. `15$`, `150 рублей в евро`, `100 eur in gbp`;
 
 ### Install plugins

--- a/app/plugins/core/plugins/initializeAsync.js
+++ b/app/plugins/core/plugins/initializeAsync.js
@@ -8,7 +8,7 @@ import getInstalledPlugins from './getInstalledPlugins'
 
 const DEFAULT_PLUGINS = [
   process.platform === 'darwin' ? 'cerebro-mac-apps' : '@cerebroapp/cerebro-basic-apps',
-  'cerebro-google',
+  '@cerebroapp/search',
   'cerebro-math',
   'cerebro-converter',
   'cerebro-open-web',


### PR DESCRIPTION
Now we will use `cerebro-search` instead of `cerebro-google`. This will help users to choose their favourite search engine instead of forcing them to use google.

fix #611 