### PR TITLE
Update the grammar in the README + add command in build from source process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ## Usage
 
-You can download the latest version on  [releases](https://github.com/cerebroapp/cerebro/releases) page.
+You can download the latest version on the [releases](https://github.com/cerebroapp/cerebro/releases) page.
 
-- If there is not installer for your OS check [build instructions](#build-executable-from-source).
+- If there isn't an installer for your OS, check [build instructions](#build-executable-from-source).
 - If you are a linux user see [how to install the executable](#install-executable-on-linux)
 
-After installation use the default shortcut `ctrl+space` to show the app window. You can customize this shortcut clicking on the icon in the menu bar and then selecting "Preferences...".
+After the installation, use the default shortcut, `ctrl+space`, to show the app window. You can customize this shortcut by clicking on the icon in the menu bar, and then selecting "Preferences...".
 
 ![Cerebro](https://cloud.githubusercontent.com/assets/594298/20180624/858a483a-a75b-11e6-94a1-ef1edc4d95c3.gif)
 
@@ -19,9 +19,9 @@ After installation use the default shortcut `ctrl+space` to show the app window.
 
 ### Core plugins
 
-- Search in the web with your favourite search engine
+- Search the web with your favourite search engine
 - Search & launch application, i.e. `spotify`
-- Navigate in file system with file previews (i.e. `~/Dropbox/passport.pdf`)
+- Navigate the file system with file previews (i.e. `~/Dropbox/passport.pdf`)
 - Calculator
 - Smart converter. `15$`, `150 рублей в евро`, `100 eur in gbp`;
 
@@ -31,7 +31,7 @@ You can manage and install more plugins by typing `plugins <plugin-name>` in the
 
 Discover plugins and more at [Cerebro's Awesome List](https://github.com/lubien/awesome-cerebro).
 
-> If you are interested in creating your own plugin, check the [plugins documentation](./docs/plugins-developers.md).
+> If you're interested in creating your own plugin, check the [plugins documentation](./docs/plugins-developers.md).
 
 ## Shortcuts
 
@@ -43,7 +43,7 @@ Cerebro provides several shortcuts to improve your productivity:
 
 ### Change Theme
 
-Use shortcut `ctrl+space` to open app window and type `Cerebro Settings`. There you will be able to change the Theme.
+Use the shortcut `ctrl+space` to open the app window, and type `Cerebro Settings`. There you will be able to change the Theme.
 
 > Currently Light and Dark Themes are supported out of the box
 
@@ -59,16 +59,19 @@ You can find the config file in the following path depending on your OS:
 
 *macOS*: `~/Library/Application Support/Cerebro/config.json`
 
-> ⚠️ A bad configuration file can break Cerebro. If you are not sure about what you are doing, don't edit the config file directly.
+> ⚠️ A bad configuration file can break Cerebro. If you're not sure what you're doing, don't edit the config file directly.
 
 ## Build executable from source
 
-If you would like to install one version of Cerebro but the executable has not been released you can follow this isntruction to build it from source:
+If you'd like to install a version of Cerebro, but the executable hasn't been released, you can follow these instructions to build it from source:
 
 1. Clone the repository
-2. Install dependencies with `yarn`
-
-3. ```bash
+2. Install dependencies with [yarn](https://yarnpkg.com/getting-started/install):
+   ```bash
+   yarn --force
+   ```
+3. Build the package:
+   ```bash
     yarn package
    ```
 
@@ -76,27 +79,27 @@ If you would like to install one version of Cerebro but the executable has not b
 
 ## Install executable on Linux
 
-If you are a linux user you might need to grant execution permissions to the executable. To do so, open the terminal and run the following command:
+If you're a linux user, you might need to grant execution permissions to the executable. To do so, open the terminal and run the following command:
 
 ```bash
 sudo chmod +x <path to the executable>
 ```
 
-Then you can install the executable by running the following command:
+Then, you can install the executable by running the following command:
 
-- If you are using the AppImage executable:
+- If you're using the AppImage executable:
 
   ```bash
   ./<path to the executable>
   ```
 
-- If you are using the deb executable:
+- If you're using the deb executable:
 
   ```bash
   dpkg -i <path to the executable>
   ```
 
-> In some computers you might need run these commands with elevated privileges (sudo). `sudo ./<path to the executable>` or `sudo dpkg -i <path to the executable>`
+> On some computers you might need run these commands with elevated privileges (sudo). `sudo ./<path to the executable>` or `sudo dpkg -i <path to the executable>`
 
 ## Contributing
 


### PR DESCRIPTION
- Fixed grammar to sound more natural, some misspelled words, missing words, and some missing commas. (english grammar nerd stuff)

- added `yarn --force` mentioned in https://github.com/cerebroapp/cerebro/issues/552#issuecomment-1249302400 because otherwise you get:
```
yarn run v1.22.19
$ yarn build && npx electron-builder
$ run-p build-main build-renderer
/bin/sh: run-p: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```