### PR TITLE
chore: move to `@cerebroapp/cerebro-mac-apps`

### DIFF
--- a/app/plugins/core/plugins/blacklist.js
+++ b/app/plugins/core/plugins/blacklist.js
@@ -4,5 +4,6 @@
  * The name must match (case sensitive) the name in the `package.json`.
  */
 export default [
-  'cerebro-basic-apps' // @cerebroapp/cerebro-basic-apps
+  'cerebro-basic-apps', // @cerebroapp/cerebro-basic-apps
+  'cerebro-mac-apps' // @cerebroapp/cerebro-mac-apps
 ]

--- a/app/plugins/core/plugins/getDebuggingPlugins.js
+++ b/app/plugins/core/plugins/getDebuggingPlugins.js
@@ -20,7 +20,6 @@ const getScopedPluginNames = async () => {
 
   // for each scope, get all plugins
   const scopeNames = scopeSubfolders.map((scope) => {
-    console.log('scopes', scope)
     const scopePlugins = getSymlinkedPluginsInFolder(scope)
     return scopePlugins.map((plugin) => `${scope}/${plugin}`)
   }).flat() // flatten array of arrays

--- a/app/plugins/core/plugins/initializeAsync.js
+++ b/app/plugins/core/plugins/initializeAsync.js
@@ -6,14 +6,21 @@ import {
 import loadPlugins from './loadPlugins'
 import getInstalledPlugins from './getInstalledPlugins'
 
+const OS_APPS_PLUGIN = {
+  darwin: '@cerebroapp/cerebro-mac-apps',
+  DEFAULT: '@cerebroapp/cerebro-basic-apps'
+}
+
 const DEFAULT_PLUGINS = [
-  process.platform === 'darwin' ? 'cerebro-mac-apps' : '@cerebroapp/cerebro-basic-apps',
+  OS_APPS_PLUGIN[process.platform] || OS_APPS_PLUGIN.DEFAULT,
   '@cerebroapp/search',
   'cerebro-math',
   'cerebro-converter',
   'cerebro-open-web',
   'cerebro-files-nav'
 ]
+
+console.log(DEFAULT_PLUGINS)
 
 /**
  * Check plugins for updates and start plugins autoupdater

--- a/app/plugins/core/plugins/initializeAsync.js
+++ b/app/plugins/core/plugins/initializeAsync.js
@@ -20,8 +20,6 @@ const DEFAULT_PLUGINS = [
   'cerebro-files-nav'
 ]
 
-console.log(DEFAULT_PLUGINS)
-
 /**
  * Check plugins for updates and start plugins autoupdater
  */


### PR DESCRIPTION
We will be using the new version of the package when installing plugins for the first time in Mac.

Done:
- Added `@cerebroapp/cerebro-mac-apps` to the default plugins list
- Blacklisted `cerebro-mac-apps` to avoid plugin duplicates
- Removed an unnecessary console.log statement