### PR TITLE
feat: select main input on show option

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -12,6 +12,7 @@ const schema = {
   firstStart: { type: 'boolean', default: true },
   developerMode: { type: 'boolean', default: false },
   cleanOnHide: { type: 'boolean', default: true },
+  selectOnShow: { type: 'boolean', default: false },
   hideOnBlur: { type: 'boolean', default: true },
   skipDonateDialog: { type: 'boolean', default: false },
   lastShownDonateDialog: { type: 'number', default: 0 },

--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -21,6 +21,7 @@ import {
 } from 'main/constants/ui'
 import * as searchActions from 'main/actions/search'
 
+import config from 'lib/config'
 import ResultsList from '../ResultsList'
 import StatusBar from '../StatusBar'
 import styles from './styles.module.css'
@@ -123,7 +124,12 @@ function Cerebro({
   const [mainInputFocused, setMainInputFocused] = useState(false)
   const [prevResultsLenght, setPrevResultsLenght] = useState(() => results.length)
 
-  const focusMainInput = () => mainInput.current.focus()
+  const focusMainInput = () => {
+    mainInput.current.focus()
+    if (config.get('selectOnShow')) {
+      mainInput.current.select()
+    }
+  }
 
   // suscribe to events
   useEffect(() => {

--- a/app/plugins/core/settings/Settings/index.js
+++ b/app/plugins/core/settings/Settings/index.js
@@ -20,6 +20,7 @@ function Settings({ get, set }) {
     proxy: get('proxy'),
     developerMode: get('developerMode'),
     cleanOnHide: get('cleanOnHide'),
+    selectOnShow: get('selectOnShow'),
     pluginsSettings: get('plugins'),
     crashreportingEnabled: get('crashreportingEnabled'),
     openAtLogin: get('openAtLogin')
@@ -29,8 +30,6 @@ function Settings({ get, set }) {
     set(key, value)
     setState((prevState) => ({ ...prevState, [key]: value }))
   }
-
-  console.log(state.country)
 
   return (
     <div className={styles.settings}>
@@ -78,6 +77,11 @@ function Settings({ get, set }) {
         label="Clean results on hide"
         value={state.cleanOnHide}
         onChange={(value) => changeConfig('cleanOnHide', value)}
+      />
+      <Checkbox
+        label="Select input on show"
+        value={state.selectOnShow}
+        onChange={(value) => changeConfig('selectOnShow', value)}
       />
       <Checkbox
         label="Send automatic crash reports (requires restart)"


### PR DESCRIPTION
Added a new option to automatically select the input on show.
This is really util for users who also use the option to keep the input when closing Cerebro.

fix #164 