### PR TITLE
fix: memory leak on reloading

### DIFF
--- a/app/background/background.js
+++ b/app/background/background.js
@@ -30,6 +30,3 @@ on('initializePluginAsync', ({ name }) => {
 
   console.groupEnd()
 })
-
-// Handle `reload` rpc event and reload window
-on('reload', () => window.location.reload())

--- a/app/main.development.js
+++ b/app/main.development.js
@@ -143,3 +143,7 @@ ipcMain.on('get-window-position', (event, { width, heightWithResults }) => {
 })
 
 ipcMain.on('quit', () => app.quit())
+ipcMain.on('reload', () => {
+  app.relaunch()
+  app.exit()
+})

--- a/app/main/createWindow/AppTray.js
+++ b/app/main/createWindow/AppTray.js
@@ -85,9 +85,8 @@ export default class AppTray {
           {
             label: 'Reload',
             click: () => {
-              mainWindow.reload()
-              backgroundWindow.reload()
-              backgroundWindow.hide()
+              app.relaunch()
+              app.exit()
             }
           }]
       })

--- a/app/main/main.js
+++ b/app/main/main.js
@@ -48,6 +48,3 @@ on('update-downloaded', () => (
 
 // Handle `updateTheme` rpc event and change current theme
 on('updateTheme', changeTheme)
-
-// Handle `reload` rpc event and reload window
-on('reload', () => location.reload())

--- a/app/plugins/core/reload/index.js
+++ b/app/plugins/core/reload/index.js
@@ -1,12 +1,11 @@
-import { send } from 'lib/rpc'
+import { ipcRenderer } from 'electron'
 import icon from '../icon.png'
 
 const keyword = 'reload'
 const title = 'Reload'
 const subtitle = 'Reload Cerebro App'
 const onSelect = (event) => {
-  send('reload')
-  location.reload()
+  ipcRenderer.send('reload')
   event.preventDefault()
 }
 
@@ -20,8 +19,12 @@ const fn = ({ term, display }) => {
   const match = term.match(/^reload\s*/)
 
   if (match) {
-    display({ icon, title, subtitle, onSelect })
+    display({
+      icon, title, subtitle, onSelect
+    })
   }
 }
 
-export default { keyword, fn, icon, name: 'Reload' }
+export default {
+  keyword, fn, icon, name: 'Reload'
+}


### PR DESCRIPTION
We were reloading only the two renderer processes. This was causing the main process to continue subscribed to older renderers that were not existing.

```bash
(node:22748) MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 render-view-deleted listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
```

Now when using the `reload` command, both the main process and the renderer processes will be reloaded. This makes Cerebro to reload a bit slower but avoids memory leaks.
