### PR TITLE
feat(plugins): improve plugins load

### DIFF
--- a/app/background/background.js
+++ b/app/background/background.js
@@ -1,18 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import plugins from 'plugins'
 import { on, send } from 'lib/rpc'
 import { settings as pluginSettings, modulesDirectory } from 'lib/plugins'
+import PluginsService from 'plugins'
 
 global.React = React
 global.ReactDOM = ReactDOM
-global.isBackground = true
 
 on('initializePluginAsync', ({ name }) => {
   console.group(`Initialize async plugin ${name}`)
 
   try {
-    const plugin = plugins[name] || window.require(`${modulesDirectory}/${name}`)
+    const plugin = PluginsService.getCorePlugins()[name] || window.require(`${modulesDirectory}/${name}`)
     const { initializeAsync } = plugin
 
     if (!initializeAsync) {

--- a/app/background/background.js
+++ b/app/background/background.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import plugins from 'plugins'
 import { on, send } from 'lib/rpc'
 import { settings as pluginSettings, modulesDirectory } from 'lib/plugins'
-import PluginsService from 'plugins'
 
 global.React = React
 global.ReactDOM = ReactDOM
@@ -11,7 +11,8 @@ on('initializePluginAsync', ({ name }) => {
   console.group(`Initialize async plugin ${name}`)
 
   try {
-    const plugin = PluginsService.getCorePlugins()[name] || window.require(`${modulesDirectory}/${name}`)
+    const plugin = plugins.getCorePlugins()[name] || window.require(`${modulesDirectory}/${name}`)
+    console.log({ plugin })
     const { initializeAsync } = plugin
 
     if (!initializeAsync) {

--- a/app/background/background.js
+++ b/app/background/background.js
@@ -8,12 +8,13 @@ global.React = React
 global.ReactDOM = ReactDOM
 
 on('initializePluginAsync', ({ name }) => {
+  const { corePlugins } = plugins
   console.group(`Initialize async plugin ${name}`)
 
   try {
-    const plugin = plugins.getCorePlugins()[name] || window.require(`${modulesDirectory}/${name}`)
-    console.log({ plugin })
-    const { initializeAsync } = plugin
+    const plugin = corePlugins[name] || window.require(`${modulesDirectory}/${name}`)
+    console.log({ corePlugins })
+    const { initializeAsync } = corePlugins
 
     if (!initializeAsync) {
       console.log('no `initializeAsync` function, skipped')

--- a/app/background/background.js
+++ b/app/background/background.js
@@ -8,13 +8,12 @@ global.React = React
 global.ReactDOM = ReactDOM
 
 on('initializePluginAsync', ({ name }) => {
-  const { corePlugins } = plugins
+  const { allPlugins } = plugins
   console.group(`Initialize async plugin ${name}`)
 
   try {
-    const plugin = corePlugins[name] || window.require(`${modulesDirectory}/${name}`)
-    console.log({ corePlugins })
-    const { initializeAsync } = corePlugins
+    const plugin = allPlugins[name] || window.require(`${modulesDirectory}/${name}`)
+    const { initializeAsync } = plugin
 
     if (!initializeAsync) {
       console.log('no `initializeAsync` function, skipped')

--- a/app/background/index.html
+++ b/app/background/index.html
@@ -1,19 +1,23 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval';"/>
-    <script>
-      (function() {
-        const script = document.createElement('script');
-        script.async = true;
-        script.src = (process.env.NODE_ENV)
-          ? 'http://localhost:3000/dist/background.bundle.js'
-          : '../dist/background.bundle.js';
-        document.write(script.outerHTML);
-      }());
-    </script>
-  </head>
-  <body>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval';" />
+  <script>
+    global.isBackground = true;
+    (function () {
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = (process.env.NODE_ENV)
+        ? 'http://localhost:3000/dist/background.bundle.js'
+        : '../dist/background.bundle.js';
+      document.write(script.outerHTML);
+    }());
+  </script>
+</head>
+
+<body>
+</body>
+
 </html>

--- a/app/background/index.html
+++ b/app/background/index.html
@@ -1,23 +1,20 @@
 <!doctype html>
 <html>
-
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval';" />
-  <script>
-    global.isBackground = true;
-    (function () {
-      const script = document.createElement('script');
-      script.async = true;
-      script.src = (process.env.NODE_ENV)
-        ? 'http://localhost:3000/dist/background.bundle.js'
-        : '../dist/background.bundle.js';
-      document.write(script.outerHTML);
-    }());
-  </script>
-</head>
-
-<body>
-</body>
-
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="script-src * 'unsafe-inline' 'unsafe-eval';" />
+    <script>
+      global.isBackground = true;
+      (function () {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = (process.env.NODE_ENV)
+          ? 'http://localhost:3000/dist/background.bundle.js'
+          : '../dist/background.bundle.js';
+        document.write(script.outerHTML);
+      }());
+    </script>
+  </head>
+  <body>
+  </body>
 </html>

--- a/app/lib/initializePlugins.js
+++ b/app/lib/initializePlugins.js
@@ -6,13 +6,13 @@ import initPlugin from './initPlugin'
  * Initialize all plugins and start listening for replies from plugin async initializers
  */
 const initializePlugins = () => {
+  const { allPlugins } = plugins
+
   // Start listening for replies from plugin async initializers
   on('plugin.message', ({ name, data }) => {
-    const plugin = plugins.getAllPlugins()[name]
+    const plugin = allPlugins[name]
     if (plugin.onMessage) plugin.onMessage(data)
   })
-
-  const allPlugins = plugins.getAllPlugins()
 
   Object.keys(allPlugins).forEach((name) => initPlugin(allPlugins[name], name))
 }

--- a/app/lib/initializePlugins.js
+++ b/app/lib/initializePlugins.js
@@ -1,16 +1,22 @@
 import { on } from 'lib/rpc'
-import plugins from 'plugins'
+import PluginsService from 'plugins'
 import initPlugin from './initPlugin'
 
+function listenToAsyncMessages() {
+  on('plugin.message', ({ name, data }) => {
+    const plugin = PluginsService.getAllPlugins()[name]
+    if (plugin.onMessage) plugin.onMessage(data)
+  })
+}
+
 /**
- * Starts listening for `initializePlugin` events and initializes all plugins
+ * Initialize all plugins and start listening for replies from plugin async initializers
  */
 export default () => {
   // Start listening for replies from plugin async initializers
-  on('plugin.message', ({ name, data }) => {
-    const plugin = plugins[name]
-    if (plugin.onMessage) plugin.onMessage(data)
-  })
+  listenToAsyncMessages()
 
-  Object.keys(plugins).forEach((name) => initPlugin(plugins[name], name))
+  const allPlugins = PluginsService.getAllPlugins()
+
+  Object.keys(allPlugins).forEach((name) => initPlugin(allPlugins[name], name))
 }

--- a/app/lib/initializePlugins.js
+++ b/app/lib/initializePlugins.js
@@ -7,14 +7,13 @@ import initPlugin from './initPlugin'
  */
 const initializePlugins = () => {
   const { allPlugins } = plugins
+  Object.keys(allPlugins).forEach((name) => initPlugin(allPlugins[name], name))
 
   // Start listening for replies from plugin async initializers
   on('plugin.message', ({ name, data }) => {
     const plugin = allPlugins[name]
-    if (plugin.onMessage) plugin.onMessage(data)
+    if (plugin && plugin.onMessage) plugin.onMessage(data)
   })
-
-  Object.keys(allPlugins).forEach((name) => initPlugin(allPlugins[name], name))
 }
 
 export default initializePlugins

--- a/app/lib/initializePlugins.js
+++ b/app/lib/initializePlugins.js
@@ -1,22 +1,20 @@
 import { on } from 'lib/rpc'
-import PluginsService from 'plugins'
+import plugins from 'plugins'
 import initPlugin from './initPlugin'
-
-function listenToAsyncMessages() {
-  on('plugin.message', ({ name, data }) => {
-    const plugin = PluginsService.getAllPlugins()[name]
-    if (plugin.onMessage) plugin.onMessage(data)
-  })
-}
 
 /**
  * Initialize all plugins and start listening for replies from plugin async initializers
  */
-export default () => {
+const initializePlugins = () => {
   // Start listening for replies from plugin async initializers
-  listenToAsyncMessages()
+  on('plugin.message', ({ name, data }) => {
+    const plugin = plugins.getAllPlugins()[name]
+    if (plugin.onMessage) plugin.onMessage(data)
+  })
 
-  const allPlugins = PluginsService.getAllPlugins()
+  const allPlugins = plugins.getAllPlugins()
 
   Object.keys(allPlugins).forEach((name) => initPlugin(allPlugins[name], name))
 }
+
+export default initializePlugins

--- a/app/main/actions/search.js
+++ b/app/main/actions/search.js
@@ -16,8 +16,6 @@ import {
 
 import store from '../store'
 
-const allPlugins = plugins.getAllPlugins()
-
 const remote = process.type === 'browser'
   ? undefined
   : require('@electron/remote')
@@ -44,6 +42,7 @@ const DEFAULT_SCOPE = {
  * @param {Function} display Callback function that receives used search term and found results
  */
 const eachPlugin = (term, display) => {
+  const { allPlugins } = plugins
   // TODO: order results by frequency?
   Object.keys(allPlugins).forEach((name) => {
     const plugin = allPlugins[name]

--- a/app/main/actions/search.js
+++ b/app/main/actions/search.js
@@ -1,4 +1,4 @@
-import PluginsService from 'plugins'
+import plugins from 'plugins'
 import config from 'lib/config'
 import { shell, clipboard } from 'electron'
 
@@ -15,6 +15,8 @@ import {
 } from 'main/constants/actionTypes'
 
 import store from '../store'
+
+const allPlugins = plugins.getAllPlugins()
 
 const remote = process.type === 'browser'
   ? undefined
@@ -43,7 +45,6 @@ const DEFAULT_SCOPE = {
  */
 const eachPlugin = (term, display) => {
   // TODO: order results by frequency?
-  const allPlugins = PluginsService.getAllPlugins()
   Object.keys(allPlugins).forEach((name) => {
     const plugin = allPlugins[name]
     try {

--- a/app/main/actions/search.js
+++ b/app/main/actions/search.js
@@ -1,4 +1,4 @@
-import plugins from 'plugins'
+import PluginsService from 'plugins'
 import config from 'lib/config'
 import { shell, clipboard } from 'electron'
 
@@ -43,8 +43,9 @@ const DEFAULT_SCOPE = {
  */
 const eachPlugin = (term, display) => {
   // TODO: order results by frequency?
-  Object.keys(plugins).forEach((name) => {
-    const plugin = plugins[name]
+  const allPlugins = PluginsService.getAllPlugins()
+  Object.keys(allPlugins).forEach((name) => {
+    const plugin = allPlugins[name]
     try {
       plugin.fn({
         ...DEFAULT_SCOPE,

--- a/app/plugins/core/autocomplete/index.js
+++ b/app/plugins/core/autocomplete/index.js
@@ -2,7 +2,7 @@ import { search } from 'cerebro-tools'
 import {
   flow, filter, map, partialRight, values
 } from 'lodash/fp'
-import getExternalPlugins from 'plugins/externalPlugins'
+import externalPlugins from 'plugins/externalPlugins'
 import quit from 'plugins/core/quit'
 import plugins from 'plugins/core/plugins'
 import settings from 'plugins/core/settings'
@@ -10,7 +10,7 @@ import version from 'plugins/core/version'
 import reload from 'plugins/core/reload'
 
 const allPlugins = {
-  quit, plugins, settings, version, reload, ...getExternalPlugins()
+  quit, plugins, settings, version, reload, ...externalPlugins
 }
 
 const toString = (plugin) => plugin.keyword

--- a/app/plugins/core/autocomplete/index.js
+++ b/app/plugins/core/autocomplete/index.js
@@ -2,7 +2,16 @@ import { search } from 'cerebro-tools'
 import {
   flow, filter, map, partialRight, values
 } from 'lodash/fp'
-import PluginsService from 'plugins'
+import getExternalPlugins from 'plugins/externalPlugins'
+import quit from 'plugins/core/quit'
+import plugins from 'plugins/core/plugins'
+import settings from 'plugins/core/settings'
+import version from 'plugins/core/version'
+import reload from 'plugins/core/reload'
+
+const allPlugins = {
+  quit, plugins, settings, version, reload, ...getExternalPlugins()
+}
 
 const toString = (plugin) => plugin.keyword
 const notMatch = (term) => (plugin) => (
@@ -32,6 +41,6 @@ const fn = ({ term, display, actions }) => flow(
   filter(notMatch(term)),
   map(pluginToResult(actions)),
   display
-)(PluginsService.getAllPlugins())
+)(allPlugins)
 
 export default { fn, name: 'Plugins autocomplete' }

--- a/app/plugins/core/autocomplete/index.js
+++ b/app/plugins/core/autocomplete/index.js
@@ -2,7 +2,7 @@ import { search } from 'cerebro-tools'
 import {
   flow, filter, map, partialRight, values
 } from 'lodash/fp'
-import plugins from 'plugins'
+import PluginsService from 'plugins'
 
 const toString = (plugin) => plugin.keyword
 const notMatch = (term) => (plugin) => (
@@ -32,6 +32,6 @@ const fn = ({ term, display, actions }) => flow(
   filter(notMatch(term)),
   map(pluginToResult(actions)),
   display
-)(plugins)
+)(PluginsService.getAllPlugins())
 
 export default { fn, name: 'Plugins autocomplete' }

--- a/app/plugins/core/plugins/Preview/index.js
+++ b/app/plugins/core/plugins/Preview/index.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { KeyboardNav, KeyboardNavItem } from '@cerebroapp/cerebro-ui'
 import { client } from 'lib/plugins'
-import plugins from 'plugins'
 import ReactMarkdown from 'react-markdown'
 
 import ActionButton from './ActionButton.js'
@@ -60,7 +59,7 @@ function Preview({ onComplete, plugin }) {
   } = plugin
 
   const githubRepo = repo && repo.match(/^.+github.com\/([^\/]+\/[^\/]+).*?/)
-  const settings = plugins[name] ? plugins[name].settings : null
+  const settings = plugin?.settings || null
   return (
     <div className={styles.preview} key={name}>
       <h2>{`${format.name(name)} (${version})`}</h2>
@@ -69,42 +68,42 @@ function Preview({ onComplete, plugin }) {
       <KeyboardNav>
         <div className={styles.header}>
 
-          { settings && (
-          <KeyboardNavItem onSelect={() => setShowSettings((prev) => !prev)}>
-            Settings
-          </KeyboardNavItem>
+          {settings && (
+            <KeyboardNavItem onSelect={() => setShowSettings((prev) => !prev)}>
+              Settings
+            </KeyboardNavItem>
           )}
 
           {showSettings && <Settings name={name} settings={settings} />}
 
-          { !isInstalled && !isDebugging && (
-          <ActionButton
-            action={pluginAction(name, 'install')}
-            text={runningAction === 'install' ? 'Installing...' : 'Install'}
-            onComplete={onCompleteAction}
-          />
+          {!isInstalled && !isDebugging && (
+            <ActionButton
+              action={pluginAction(name, 'install')}
+              text={runningAction === 'install' ? 'Installing...' : 'Install'}
+              onComplete={onCompleteAction}
+            />
           )}
 
-          { isInstalled && (
-          <ActionButton
-            action={pluginAction(name, 'uninstall')}
-            text={runningAction === 'uninstall' ? 'Uninstalling...' : 'Uninstall'}
-            onComplete={onCompleteAction}
-          />
+          {isInstalled && (
+            <ActionButton
+              action={pluginAction(name, 'uninstall')}
+              text={runningAction === 'uninstall' ? 'Uninstalling...' : 'Uninstall'}
+              onComplete={onCompleteAction}
+            />
           )}
 
-          { isUpdateAvailable && (
-          <ActionButton
-            action={pluginAction(name, 'update')}
-            text={runningAction === 'update' ? 'Updating...' : `Update (${installedVersion} → ${version})`}
-            onComplete={onCompleteAction}
-          />
+          {isUpdateAvailable && (
+            <ActionButton
+              action={pluginAction(name, 'update')}
+              text={runningAction === 'update' ? 'Updating...' : `Update (${installedVersion} → ${version})`}
+              onComplete={onCompleteAction}
+            />
           )}
 
-          { githubRepo && (
-          <KeyboardNavItem onSelect={() => setShowDescription((prev) => !prev)}>
-            Details
-          </KeyboardNavItem>
+          {githubRepo && (
+            <KeyboardNavItem onSelect={() => setShowDescription((prev) => !prev)}>
+              Details
+            </KeyboardNavItem>
           )}
 
         </div>

--- a/app/plugins/core/plugins/getInstalledPlugins.js
+++ b/app/plugins/core/plugins/getInstalledPlugins.js
@@ -1,6 +1,6 @@
 import { packageJsonPath } from 'lib/plugins'
 import { readFile } from 'fs/promises'
-import getExternalPlugins from 'plugins/externalPlugins'
+import externalPlugins from 'plugins/externalPlugins'
 
 const readPackageJson = async () => {
   try {
@@ -20,7 +20,6 @@ const readPackageJson = async () => {
 export default async () => {
   const packageJson = await readPackageJson()
   const result = {}
-  const externalPlugins = getExternalPlugins()
 
   Object.keys(externalPlugins).forEach((pluginName) => {
     result[pluginName] = { ...externalPlugins[pluginName], version: packageJson.dependencies[pluginName] || '0.0.0' }

--- a/app/plugins/core/plugins/getInstalledPlugins.js
+++ b/app/plugins/core/plugins/getInstalledPlugins.js
@@ -1,6 +1,6 @@
 import { packageJsonPath } from 'lib/plugins'
 import { readFile } from 'fs/promises'
-import PluginsService from 'plugins'
+import getExternalPlugins from 'plugins/externalPlugins'
 
 const readPackageJson = async () => {
   try {
@@ -20,7 +20,7 @@ const readPackageJson = async () => {
 export default async () => {
   const packageJson = await readPackageJson()
   const result = {}
-  const externalPlugins = PluginsService.getExternalPlugins()
+  const externalPlugins = getExternalPlugins()
 
   Object.keys(externalPlugins).forEach((pluginName) => {
     result[pluginName] = { ...externalPlugins[pluginName], version: packageJson.dependencies[pluginName] || '0.0.0' }

--- a/app/plugins/core/plugins/getInstalledPlugins.js
+++ b/app/plugins/core/plugins/getInstalledPlugins.js
@@ -1,5 +1,6 @@
 import { packageJsonPath } from 'lib/plugins'
 import { readFile } from 'fs/promises'
+import PluginsService from 'plugins'
 
 const readPackageJson = async () => {
   try {
@@ -14,9 +15,16 @@ const readPackageJson = async () => {
 /**
  * Get list of all installed plugins with versions
  *
- * @return {Promise<{[name: string]: string}>}
+ * @return {Promise<{[name: string]: Record<string, any>}>}
  */
 export default async () => {
   const packageJson = await readPackageJson()
-  return packageJson?.dependencies || {}
+  const result = {}
+  const externalPlugins = PluginsService.getExternalPlugins()
+
+  Object.keys(externalPlugins).forEach((pluginName) => {
+    result[pluginName] = { ...externalPlugins[pluginName], version: packageJson.dependencies[pluginName] || '0.0.0' }
+  })
+
+  return result
 }

--- a/app/plugins/core/plugins/loadPlugins.js
+++ b/app/plugins/core/plugins/loadPlugins.js
@@ -21,21 +21,24 @@ export default async () => {
     getDebuggingPlugins()
   ])
 
-  const listOfInstalledPlugins = Object.entries(installed).map(([name, version]) => ({
+  const listOfInstalledPlugins = Object.entries(installed).map(([name, { version }]) => ({
     name,
     version,
     installedVersion: parseVersion(version),
     isInstalled: true,
-    isUpdateAvailable: false,
+    settings: installed[name].settings,
+    isUpdateAvailable: false
   }))
 
   const listOfAvailablePlugins = available.map((plugin) => {
-    const installedVersion = installed[plugin.name]
+    const installedVersion = installed[plugin.name]?.version
     if (!installedVersion) { return plugin }
 
     const isUpdateAvailable = compareVersions(plugin.version, parseVersion(installedVersion))
+    const installedPluginInfo = listOfInstalledPlugins.find((p) => p.name === plugin.name)
     return {
       ...plugin,
+      ...installedPluginInfo,
       installedVersion,
       isInstalled: true,
       isUpdateAvailable

--- a/app/plugins/externalPlugins.js
+++ b/app/plugins/externalPlugins.js
@@ -50,7 +50,7 @@ const getPluginName = (pluginPath) => {
 
 const plugins = {}
 
-function setupPluginsWatcher() {
+const setupPluginsWatcher = () => {
   if (global.isBackground) return
 
   const pluginsWatcher = chokidar.watch(modulesDirectory, { depth: 1 })
@@ -108,6 +108,6 @@ function setupPluginsWatcher() {
 
 setupPluginsWatcher()
 
-export default function getExternalPlugins() {
-  return plugins
-}
+const getExternalPlugins = () => plugins
+
+export default getExternalPlugins

--- a/app/plugins/externalPlugins.js
+++ b/app/plugins/externalPlugins.js
@@ -28,10 +28,10 @@ const requirePlugin = (pluginPath) => {
  */
 const isPluginValid = (plugin) => (
   plugin
-    // Check existing of main plugin function
-    && typeof plugin.fn === 'function'
-    // Check that plugin function accepts 0 or 1 argument
-    && plugin.fn.length <= 1
+  // Check existing of main plugin function
+  && typeof plugin.fn === 'function'
+  // Check that plugin function accepts 0 or 1 argument
+  && plugin.fn.length <= 1
 )
 
 ensureFiles()
@@ -50,59 +50,64 @@ const getPluginName = (pluginPath) => {
 
 const plugins = {}
 
-const pluginsWatcher = chokidar.watch(modulesDirectory, { depth: 1 })
+function setupPluginsWatcher() {
+  if (global.isBackground) return
 
-pluginsWatcher.on('unlinkDir', (pluginPath) => {
-  const { base, dir } = path.parse(pluginPath)
-  if (base.match(/node_modules/) || base.match(/^@/)) return
-  if (!dir.match(/node_modules$/) && !dir.match(/@.+$/)) return
+  const pluginsWatcher = chokidar.watch(modulesDirectory, { depth: 1 })
+  pluginsWatcher.on('unlinkDir', (pluginPath) => {
+    const { base, dir } = path.parse(pluginPath)
+    if (base.match(/node_modules/) || base.match(/^@/)) return
+    if (!dir.match(/node_modules$/) && !dir.match(/@.+$/)) return
 
-  const pluginName = getPluginName(pluginPath)
+    const pluginName = getPluginName(pluginPath)
 
-  const requirePath = window.require.resolve(pluginPath)
-  delete plugins[pluginName]
-  delete window.require.cache[requirePath]
-  console.log(`[${pluginName}] Plugin removed`)
-})
-
-pluginsWatcher.on('addDir', (pluginPath) => {
-  const { base, dir } = path.parse(pluginPath)
-
-  if (base.match(/node_modules/) || base.match(/^@/)) return
-  if (!dir.match(/node_modules$/) && !dir.match(/@.+$/)) return
-
-  const pluginName = getPluginName(pluginPath)
-
-  setTimeout(() => {
-    console.group(`Load plugin: ${pluginName}`)
-    console.log(`Path: ${pluginPath}...`)
-    const plugin = requirePlugin(pluginPath)
-    if (!isPluginValid(plugin)) {
-      console.log('Plugin is not valid, skipped')
-      console.groupEnd()
-      return
-    }
-    if (!settings.validate(plugin)) {
-      console.log('Invalid plugins settings')
-      console.groupEnd()
-      return
-    }
-
-    console.log('Loaded.')
     const requirePath = window.require.resolve(pluginPath)
-    const watcher = chokidar.watch(pluginPath, { depth: 0 })
-    watcher.on('change', debounce(() => {
-      console.log(`[${pluginName}] Update plugin`)
-      delete window.require.cache[requirePath]
-      plugins[pluginName] = window.require(pluginPath)
-      console.log(`[${pluginName}] Plugin updated`)
-    }, 1000))
-    plugins[pluginName] = plugin
-    if (!global.isBackground) {
-      initPlugin(plugin, pluginName)
-    }
-    console.groupEnd()
-  }, 1000)
-})
+    delete plugins[pluginName]
+    delete window.require.cache[requirePath]
+    console.log(`[${pluginName}] Plugin removed`)
+  })
 
-export default plugins
+  pluginsWatcher.on('addDir', (pluginPath) => {
+    const { base, dir } = path.parse(pluginPath)
+
+    if (base.match(/node_modules/) || base.match(/^@/)) return
+    if (!dir.match(/node_modules$/) && !dir.match(/@.+$/)) return
+
+    const pluginName = getPluginName(pluginPath)
+
+    setTimeout(() => {
+      console.group(`Load plugin: ${pluginName}`)
+      console.log(`Path: ${pluginPath}...`)
+      const plugin = requirePlugin(pluginPath)
+      if (!isPluginValid(plugin)) {
+        console.log('Plugin is not valid, skipped')
+        console.groupEnd()
+        return
+      }
+      if (!settings.validate(plugin)) {
+        console.log('Invalid plugins settings')
+        console.groupEnd()
+        return
+      }
+
+      console.log('Loaded.')
+      const requirePath = window.require.resolve(pluginPath)
+      const watcher = chokidar.watch(pluginPath, { depth: 0 })
+      watcher.on('change', debounce(() => {
+        console.log(`[${pluginName}] Update plugin`)
+        delete window.require.cache[requirePath]
+        plugins[pluginName] = window.require(pluginPath)
+        console.log(`[${pluginName}] Plugin updated`)
+      }, 1000))
+      plugins[pluginName] = plugin
+      initPlugin(plugin, pluginName)
+      console.groupEnd()
+    }, 1000)
+  })
+}
+
+setupPluginsWatcher()
+
+export default function getExternalPlugins() {
+  return plugins
+}

--- a/app/plugins/externalPlugins.js
+++ b/app/plugins/externalPlugins.js
@@ -108,6 +108,4 @@ const setupPluginsWatcher = () => {
 
 setupPluginsWatcher()
 
-const getExternalPlugins = () => plugins
-
-export default getExternalPlugins
+export default plugins

--- a/app/plugins/externalPlugins.js
+++ b/app/plugins/externalPlugins.js
@@ -4,6 +4,8 @@ import path from 'path'
 import initPlugin from 'lib/initPlugin'
 import { modulesDirectory, ensureFiles, settings } from 'lib/plugins'
 
+const plugins = {}
+
 const requirePlugin = (pluginPath) => {
   try {
     let plugin = window.require(pluginPath)
@@ -47,8 +49,6 @@ const getPluginName = (pluginPath) => {
   if (!scope) return base
   return `${scope[0]}/${base}`
 }
-
-const plugins = {}
 
 const setupPluginsWatcher = () => {
   if (global.isBackground) return

--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -1,10 +1,10 @@
 import core from './core'
-import getExternalPlugins from './externalPlugins'
+import externalPlugins from './externalPlugins'
 
 const pluginsService = {
   corePlugins: core,
-  allPlugins: { ...core, ...getExternalPlugins() },
-  externalPlugins: getExternalPlugins()
+  allPlugins: Object.assign(externalPlugins, core),
+  externalPlugins,
 }
 
 export default pluginsService

--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -1,14 +1,10 @@
 import core from './core'
 import getExternalPlugins from './externalPlugins'
 
-const getCorePlugins = () => core
-
-const getAllPlugins = () => ({ ...core, ...getExternalPlugins() })
-
 const pluginsService = {
-  getExternalPlugins,
-  getCorePlugins,
-  getAllPlugins,
+  corePlugins: core,
+  allPlugins: { ...core, ...getExternalPlugins() },
+  externalPlugins: getExternalPlugins()
 }
 
 export default pluginsService

--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -1,4 +1,18 @@
 import core from './core'
-import externalPlugins from './externalPlugins'
+import getExternalPlugins from './externalPlugins'
 
-export default Object.assign(externalPlugins, core)
+class PluginsService {
+  getCorePlugins() {
+    return core
+  }
+
+  getExternalPlugins() {
+    return getExternalPlugins()
+  }
+
+  getAllPlugins() {
+    return { ...core, ...getExternalPlugins() }
+  }
+}
+
+export default new PluginsService()

--- a/app/plugins/index.js
+++ b/app/plugins/index.js
@@ -1,18 +1,14 @@
 import core from './core'
 import getExternalPlugins from './externalPlugins'
 
-class PluginsService {
-  getCorePlugins() {
-    return core
-  }
+const getCorePlugins = () => core
 
-  getExternalPlugins() {
-    return getExternalPlugins()
-  }
+const getAllPlugins = () => ({ ...core, ...getExternalPlugins() })
 
-  getAllPlugins() {
-    return { ...core, ...getExternalPlugins() }
-  }
+const pluginsService = {
+  getExternalPlugins,
+  getCorePlugins,
+  getAllPlugins,
 }
 
-export default new PluginsService()
+export default pluginsService


### PR DESCRIPTION
This PR should make Cerebro more performant.

The idea of the double renderer process was to make the second take care of the heavier tasks.
However, it was doing too much work by duplicating tasks that are already done in the main renderer.

The loading of plugins and the control over the addition of new plugins was being done in both renderers, which led to an unnecessary waste of resources (duplicated chockidar instances watching folders, double loading of plugins)

![image](https://user-images.githubusercontent.com/77246331/206716513-2989566e-0c23-4910-ad2e-f83080358747.png)

With this PR, we make the second renderer do what it is supposed to do: take care of the async loads of plugins

![image](https://user-images.githubusercontent.com/77246331/206717465-5ba6411b-597b-4992-844f-d77a612d87c1.png)


ref #118



