### PR TITLE
feat(main window): display main window on the screen containing or closest to the mouse pointer

### DIFF
--- a/app/main.development.js
+++ b/app/main.development.js
@@ -8,6 +8,10 @@ import AppTray from './main/createWindow/AppTray'
 import autoStart from './main/createWindow/autoStart'
 import initAutoUpdater from './initAutoUpdater'
 
+import {
+  WINDOW_WIDTH,
+} from 'main/constants/ui'
+
 const iconSrc = {
   DEFAULT: `${__dirname}/tray_icon.png`,
   darwin: `${__dirname}/tray_iconTemplate@2x.png`,
@@ -38,12 +42,27 @@ const setupEnvVariables = () => {
 }
 
 app.whenReady().then(() => {
+  // We cannot require the screen module until the app is ready.
+  const { screen } = require('electron')
+
   setupEnvVariables()
 
   mainWindow = createMainWindow({
     isDev,
     src: `file://${__dirname}/main/index.html`, // Main window html
   })
+
+  mainWindow.on('show', (event) => {
+    const cursorScreenPoint = screen.getCursorScreenPoint()
+    const nearestDisplay = screen.getDisplayNearestPoint(cursorScreenPoint)
+
+    const goalWidth = WINDOW_WIDTH
+    const goalX = Math.floor(nearestDisplay.bounds.x + (nearestDisplay.size.width - goalWidth) / 2)
+    const goalY = nearestDisplay.bounds.y + 200 // "top" is hardcoded now, should get from config or calculate accordingly?
+
+    config.set('winPosition', [goalX, goalY])
+  })
+
   // eslint-disable-next-line global-require
   require('@electron/remote/main').initialize()
   // eslint-disable-next-line global-require


### PR DESCRIPTION
When displaying the main window for Cerebro so far the primary screen has been chosen. This is inconvenient for workstations with more than 1 screen. After this commit is applied the main window will be displayed in the screen containing the mouse pointer (or the screen closest to the pointer if the pointer is in between screens).

fix cerebroapp/cerebro#647

