### PR TITLE
feat(cerebro): added customization option for placeholder text on search bar

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -18,6 +18,7 @@ const schema = {
   isMigratedPlugins: { type: 'boolean', default: false },
   openAtLogin: { type: 'boolean', default: true },
   winPosition: { type: 'array', default: [] },
+  searchBarPlaceholder: { type: 'string', default: 'Cerebro Search' },
 }
 
 const store = new Store({

--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -338,7 +338,7 @@ function Cerebro({
       <Autocomplete autocompleteCalculator={autocompleteValue} />
       <div className={styles.inputWrapper}>
         <input
-          placeholder="Cerebro Search"
+          placeholder={config.get('searchBarPlaceholder')}
           type="text"
           id="main-input"
           ref={mainInput}

--- a/app/plugins/core/settings/Settings/index.js
+++ b/app/plugins/core/settings/Settings/index.js
@@ -22,7 +22,8 @@ function Settings({ get, set }) {
     cleanOnHide: get('cleanOnHide'),
     selectOnShow: get('selectOnShow'),
     pluginsSettings: get('plugins'),
-    openAtLogin: get('openAtLogin')
+    openAtLogin: get('openAtLogin'),
+    searchBarPlaceholder: get('searchBarPlaceholder')
   }))
 
   const changeConfig = (key, value) => {
@@ -56,6 +57,12 @@ function Settings({ get, set }) {
         label="Proxy"
         value={state.proxy}
         onChange={(value) => changeConfig('proxy', value)}
+      />
+      <Text
+        type="text"
+        label="Search bar placeholder"
+        value={state.searchBarPlaceholder}
+        onChange={(value) => changeConfig('searchBarPlaceholder', value)}
       />
       <Checkbox
         label="Open at login"


### PR DESCRIPTION
Now in Cerebro Config there's a new text field to customize the placeholder text on the searchbar. By default it's always "Cerebro search"

fix #672

