### PR TITLE
Don't define browserWindowOptions type as splash if desktop environment is kde

### DIFF
--- a/app/main/createWindow.js
+++ b/app/main/createWindow.js
@@ -36,7 +36,8 @@ export default ({ src, isDev }) => {
     // Show main window on launch only when application started for the first time
   }
 
-  if (process.platform === 'linux') {
+  const isKde = process.env.KDE_FULL_SESSION === "true"
+  if (process.platform === 'linux' && !isKde) {
     browserWindowOptions.type = 'splash'
   }
 


### PR DESCRIPTION
Fixes main window not accepting input or focus when running on linux with kde plasma

Connected issues:
https://github.com/cerebroapp/cerebro/issues/705
https://github.com/cerebroapp/cerebro/issues/661