### PR TITLE
Align EditorConfig TypeScript spacing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{json,js,jsx,html,css}]
+[*.{json,js,jsx,ts,tsx,html,css}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
Add ts and tsx to the two-space block so TypeScript files avoid inheriting the repo-wide tab default from the base [*] section, an inconsistency noticed after the TS migration (7526793148b). This keeps formatting aligned with our JS guidance.

