### PR TITLE
feat(settings and input bar): add option for toggling spell check

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -19,6 +19,7 @@ const schema = {
   openAtLogin: { type: 'boolean', default: true },
   winPosition: { type: 'array', default: [] },
   searchBarPlaceholder: { type: 'string', default: 'Cerebro Search' },
+  spellcheck: { type: 'boolean', default: false },
 }
 
 const store = new Store({

--- a/app/main/components/Cerebro/index.js
+++ b/app/main/components/Cerebro/index.js
@@ -348,6 +348,7 @@ function Cerebro({
           onKeyDown={onKeyDown}
           onFocus={onMainInputFocus}
           onBlur={onMainInputBlur}
+          spellCheck={config.get('spellcheck')}
         />
       </div>
       <ResultsList

--- a/app/plugins/core/settings/Settings/index.js
+++ b/app/plugins/core/settings/Settings/index.js
@@ -23,7 +23,8 @@ function Settings({ get, set }) {
     selectOnShow: get('selectOnShow'),
     pluginsSettings: get('plugins'),
     openAtLogin: get('openAtLogin'),
-    searchBarPlaceholder: get('searchBarPlaceholder')
+    searchBarPlaceholder: get('searchBarPlaceholder'),
+    spellcheck: get('spellcheck'),
   }))
 
   const changeConfig = (key, value) => {
@@ -88,6 +89,11 @@ function Settings({ get, set }) {
         label="Select input on show"
         value={state.selectOnShow}
         onChange={(value) => changeConfig('selectOnShow', value)}
+      />
+      <Checkbox
+        label="Enable spell check"
+        value={state.spellcheck}
+        onChange={(value) => changeConfig('spellcheck', value)}
       />
     </div>
   )


### PR DESCRIPTION
To address https://github.com/cerebroapp/cerebro/issues/712 we introduce a spellcheck boolean setting to control the spellCheck attribute of the input bar. By disabling the spellcheck members will not see a squiggly line under the text while they input it.

re #712

