### PR TITLE
Run production build in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,3 +17,4 @@ jobs:
             node-version: 16
         - run: yarn
         - run: yarn test --detectOpenHandles --forceExit
+        - run: yarn build


### PR DESCRIPTION
## Summary

- Add `yarn build` to the existing PR and master push CI workflow.
- Ensure production webpack bundling is checked before merge and on master pushes.
- Keep the existing workflow structure and Node.js version unchanged.

## Verification

- `yarn test --detectOpenHandles --forceExit`
- `yarn build`
- `git diff --check`
- `./node_modules/.bin/commitlint --from HEAD~1 --to HEAD --verbose`