### PR TITLE
fix: correct "Heigth" typo in RESULT_HEIGHT comment

### DIFF
--- a/app/main/constants/ui.ts
+++ b/app/main/constants/ui.ts
@@ -1,7 +1,7 @@
 // Height of main input
 export const INPUT_HEIGHT = 45
 
-// Heigth of default result line
+// Height of default result line
 export const RESULT_HEIGHT = 45
 
 // Width of main window


### PR DESCRIPTION
Small spelling fix in the comment above `RESULT_HEIGHT` (`Heigth` -> `Height`).

Comment-only change, no behaviour impact.